### PR TITLE
:sparkles: `make lint-suggestions`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ hack/tools/bin
 bin
 .pre-commit-config.yaml
 node_modules
+.vscode

--- a/.golangci-suggestions.yaml
+++ b/.golangci-suggestions.yaml
@@ -1,5 +1,5 @@
-# These linters are enforced via CI
-# See .golangci-suggestions.yaml for optional checks.
+# These linters are optional.
+# See .golangci.yaml for checks which are enforced via CI.
 linters:
   disable-all: true
   enable:
@@ -9,8 +9,11 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - decorder
     - depguard
+    - dogsled
     - durationcheck
+    - exhaustruct
     - errcheck
     - errchkjson
     - errname
@@ -19,9 +22,12 @@ linters:
     - exportloopref
     - forcetypeassert
     - gci
+    - gochecknoglobals
+    - gochecknoinits
     - goconst
     - gocritic
     - godot
+    - godox
     - goerr113
     - gofmt
     - gofumpt
@@ -30,12 +36,16 @@ linters:
     - gosec
     - gosimple
     - govet
+    - ireturn
     - importas
+    - interfacebloat
     - ineffassign
     - loggercheck
     - makezero
     - misspell
+    - musttag
     - nakedret
+    - nestif
     - nilerr
     - nilnil
     - noctx
@@ -59,7 +69,6 @@ linters:
     - unused
     - wastedassign
     - whitespace
-    - wrapcheck
 
 linters-settings:
   decorder:
@@ -91,12 +100,20 @@ linters-settings:
       # Kubernetes
       - pkg: k8s.io/api/core/v1
         alias: corev1
+  interfacebloat:
+    # The maximum number of methods allowed for an interface.
+    # Default: 10
+    max: 5
   gofumpt:
     extra-rules: true
   nolintlint:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
+  nestif:
+    # Minimal complexity of if statements to report.
+    # Default: 5
+    min-complexity: 4
   staticcheck:
     go: "1.19"
   stylecheck:
@@ -131,11 +148,10 @@ linters-settings:
             allowStrs: '""'
             allowInts: "0,1,2,10,32"
             ignoreFuncs: "Test*"
-
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#argument-limit
       - name: argument-limit
         severity: warning
-        disabled: true
+        disabled: false
         arguments: [4]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#banned-characters
       - name: banned-characters
@@ -191,12 +207,12 @@ linters-settings:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
       - name: line-length-limit
         severity: warning
-        disabled: true
+        disabled: false
         arguments: [120]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs
       - name: max-public-structs
         severity: warning
-        disabled: true
+        disabled: false
         arguments: [3]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
       - name: string-format

--- a/client/client.go
+++ b/client/client.go
@@ -45,8 +45,11 @@ var _ Interface = (*Client)(nil)
 var ErrNoSuchDevice = errors.New("no such device")
 
 // NewClient creates a struct which implements the Client interface.
-func NewClient(client *hv.APIClient) *Client {
-	return &Client{client: client}
+func NewClient(apiKey string) *Client {
+	config := hv.NewConfiguration()
+	config.AddDefaultHeader("X-API-KEY", apiKey)
+	apiClient := hv.NewAPIClient(config)
+	return &Client{client: apiClient}
 }
 
 // GetBareMetalDevice returns the device fetched via the Hivelocity API.

--- a/hivelocity/cloud.go
+++ b/hivelocity/cloud.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"os"
 
-	hv "github.com/hivelocity/hivelocity-client-go/client"
 	"github.com/hivelocity/hivelocity-cloud-controller-manager/client"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
@@ -31,7 +30,6 @@ import (
 
 // cloud implements cloudprovider.Interface for Hivelocity.
 type cloud struct {
-	client      *hv.APIClient
 	instancesV2 *HVInstancesV2
 }
 
@@ -57,16 +55,11 @@ func newCloud() (*cloud, error) {
 		return nil, errEnvVarMissing
 	}
 
-	apiClientConfig := hv.NewConfiguration()
-	apiClientConfig.AddDefaultHeader("X-API-KEY", apiKey)
-	apiClient := hv.NewAPIClient(apiClientConfig)
-
 	klog.Infof("Hivelocity cloud controller manager %s started\n", providerVersion)
 
-	i2 := newHVInstanceV2(client.NewClient(apiClient))
+	i2 := newHVInstanceV2(client.NewClient(apiKey))
 
 	return &cloud{
-		client:      apiClient,
 		instancesV2: i2,
 	}, nil
 }
@@ -76,34 +69,34 @@ func (*cloud) Initialize(cloudprovider.ControllerClientBuilder, <-chan struct{})
 }
 
 // Instances implements cloudprovider.Interface.Instances.
-func (*cloud) Instances() (cloudprovider.Instances, bool) { //nolint:ireturn // implements cloudprovider.Interface
+func (*cloud) Instances() (cloudprovider.Instances, bool) {
 	// we only implement InstancesV2
 	return nil, false
 }
 
 // InstancesV2 implements cloudprovider.Interface.InstancesV2.
-func (c *cloud) InstancesV2() (cloudprovider.InstancesV2, bool) { //nolint:ireturn // implements cloudprovider.Interface
+func (c *cloud) InstancesV2() (cloudprovider.InstancesV2, bool) {
 	return c.instancesV2, true
 }
 
 // Zones implements cloudprovider.Interface.Zones.
-func (*cloud) Zones() (cloudprovider.Zones, bool) { //nolint:ireturn // implements cloudprovider.Interface
+func (*cloud) Zones() (cloudprovider.Zones, bool) {
 	// we only implement InstancesV2
 	return nil, false
 }
 
 // LoadBalancer implements cloudprovider.Interface.LoadBalancer.
-func (c *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) { //nolint:revive,ireturn // implements cloudprovider.Interface
+func (*cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	return nil, false // TODO: Up to now Hivelocity has not API for LoadBalancers.
 }
 
 // Clusters implements cloudprovider.Interface.Clusters.
-func (*cloud) Clusters() (cloudprovider.Clusters, bool) { //nolint:ireturn // implements cloudprovider.Interface
+func (*cloud) Clusters() (cloudprovider.Clusters, bool) {
 	return nil, false // TODO: Will we implement this optional method?
 }
 
 // Routes implements cloudprovider.Interface.Routes.
-func (*cloud) Routes() (cloudprovider.Routes, bool) { //nolint:ireturn // implements cloudprovider.Interface
+func (*cloud) Routes() (cloudprovider.Routes, bool) {
 	return nil, false // TODO: Will we implement this optional method?
 }
 

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	os.Exit(code)
 }
 
-func cloudInitializer(config *cloudcontrollerconfig.CompletedConfig) cloudprovider.Interface { //nolint:ireturn,revive // implements InitCloudFunc
+func cloudInitializer(config *cloudcontrollerconfig.CompletedConfig) cloudprovider.Interface {
 	cloudConfig := config.ComponentConfig.KubeCloudShared.CloudProvider
 	cloud, err := cloudprovider.InitCloudProvider(cloudConfig.Name, cloudConfig.CloudConfigFile)
 	if err != nil {

--- a/pkg/hvutils/hvutils.go
+++ b/pkg/hvutils/hvutils.go
@@ -55,8 +55,11 @@ func GetInstanceTypeFromTags(tags []string) (string, error) {
 		return "", ErrNoInstanceTypeFound
 	}
 	if len(instanceTypes) > 1 {
-		return "", fmt.Errorf("[GetInstanceTypeFromTags] more than one instance type. instanceTypes %v: %w",
-			instanceTypes, ErrMoreThanOneTagFound)
+		return "", fmt.Errorf(
+			"[GetInstanceTypeFromTags] more than one instance type. instanceTypes %v: %w",
+			instanceTypes,
+			ErrMoreThanOneTagFound,
+		)
 	}
 	instanceType := instanceTypes[0]
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What type of PR is this?**

/kind feature           New functionality.

**What this PR does / why we need it**:

This PR adds the Makefile target `lint-suggestions`.

The target runs the linters with alternative settings, which produce more warnings.

These warnings are optional (not blocking in CI).

The target is meant to be run by developers and PR-reviewers.

Additionaly, the PR adds `makecheck` (a linter for Makefiles).

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
