### PR TITLE
:bug: Update instance type prefix to align with CAPHV

### DIFF
--- a/hivelocity/instances_v2.go
+++ b/hivelocity/instances_v2.go
@@ -183,7 +183,7 @@ func (i2 *HVInstancesV2) InstanceMetadata(
 		)
 	}
 
-	// HV tag. Example "instance-type=abc".
+	// HV tag. Example "caphv-device-type=abc".
 	instanceType, err := hvutils.GetInstanceTypeFromTags(device.Tags)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/hivelocity/instances_v2_test.go
+++ b/hivelocity/instances_v2_test.go
@@ -96,7 +96,7 @@ func standardMocks(m *mocks.Interface) {
 			OrderId:                  0,
 			OsName:                   "",
 			ProductId:                0,
-			Tags:                     []string{"instance-type=bare-metal-x"},
+			Tags:                     []string{"caphv-device-type=bare-metal-x"},
 		},
 		nil)
 

--- a/pkg/hvutils/hvutils.go
+++ b/pkg/hvutils/hvutils.go
@@ -26,22 +26,22 @@ import (
 
 var (
 
-	// ErrMoreThanOneTagFound gets returned if more than one instance-type tag was found via the HV API.
-	ErrMoreThanOneTagFound = fmt.Errorf("more than one instance-type tag found")
+	// ErrMoreThanOneTagFound gets returned if more than one caphv-device-type tag was found via the HV API.
+	ErrMoreThanOneTagFound = fmt.Errorf("more than one caphv-device-type tag found")
 
 	// ErrInvalidLabelValue gets returned if the HV tag contains a value which is an invalid K8s label.
 	ErrInvalidLabelValue = fmt.Errorf("invalid label value")
 
-	// ErrNoInstanceTypeFound gets returned if no instance-type tag was found via the HV API.
-	ErrNoInstanceTypeFound = fmt.Errorf("no instance-type tag found")
+	// ErrNoInstanceTypeFound gets returned if no caphv-device-type tag was found via the HV API.
+	ErrNoInstanceTypeFound = fmt.Errorf("no caphv-device-type tag found")
 )
 
-// GetInstanceTypeFromTags is a utility method to read the instance-type
+// GetInstanceTypeFromTags is a utility method to read the caphv-device-type
 // from a slice of strings.
 // The slice is usually from the Hivelocity API of a device.
-// Example: {"instance-type=foo", "other-label"} would return "foo".
+// Example: {"caphv-device-type=foo", "other-label"} would return "foo".
 func GetInstanceTypeFromTags(tags []string) (string, error) {
-	prefix := "instance-type="
+	prefix := "caphv-device-type="
 	instanceTypes := make([]string, 0, 1)
 	for _, tag := range tags {
 		if !strings.HasPrefix(tag, prefix) {
@@ -65,7 +65,7 @@ func GetInstanceTypeFromTags(tags []string) (string, error) {
 
 	if errs := validation.IsValidLabelValue(instanceType); len(errs) != 0 {
 		return "", fmt.Errorf("[GetInstanceTypeFromTags] Hivelocity tag is no valid K8s label. "+
-			"errors %q, instance-type %q: %w",
+			"errors %q, caphv-device-type %q: %w",
 			strings.Join(errs, "; "),
 			instanceType,
 			ErrInvalidLabelValue,

--- a/pkg/hvutils/hvutils_test.go
+++ b/pkg/hvutils/hvutils_test.go
@@ -39,19 +39,19 @@ func Test_getInstanceTypeFromTags(t *testing.T) {
 		},
 		{
 			name: "invalid label value will be skipped",
-			tags: []string{"instance-type=&"},
+			tags: []string{"caphv-device-type=&"},
 			want: "",
 			err:  ErrInvalidLabelValue,
 		},
 		{
 			name: "valid label value will be used",
-			tags: []string{"foo", "instance-type=abc", "bar", "key=value"},
+			tags: []string{"foo", "caphv-device-type=abc", "bar", "key=value"},
 			want: "abc",
 			err:  nil,
 		},
 		{
 			name: "two labels",
-			tags: []string{"instance-type=abc", "instance-type=abc"},
+			tags: []string{"caphv-device-type=abc", "caphv-device-type=abc"},
 			want: "",
 			err:  ErrMoreThanOneTagFound,
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixing the issue that the prefix for device types tags are not aligned with CAPHV

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [x] add unit tests
