### PR TITLE
🌱 include version information

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    - depguard
+    # - depguard
     - durationcheck
     - errchkjson
     - errname

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+version::get_version_vars() {
+    GIT_COMMIT="$(git rev-parse HEAD^{commit})"
+
+    if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+        GIT_TREE_STATE="clean"
+    else
+        GIT_TREE_STATE="dirty"
+    fi
+
+    # borrowed from k8s.io/hack/lib/version.sh
+    # Use git describe to find the version based on tags.
+    if GIT_VERSION=$(git describe --tags --abbrev=14 2>/dev/null); then
+        # This translates the "git describe" to an actual semver.org
+        # compatible semantic version that looks something like this:
+        #   v1.1.0-alpha.0.6+84c76d1142ea4d
+        DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
+        if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+            # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+            GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\-\2/")
+        elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+            # We have distance to base tag (v1.1.0-1-gCommitHash)
+            GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/-\1/")
+        fi
+        if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
+            # git describe --dirty only considers changes to existing files, but
+            # that is problematic since new untracked .go files affect the build,
+            # so use our idea of "dirty" from git status instead.
+            GIT_VERSION+="-dirty"
+        fi
+
+
+        # Try to match the "git describe" output to a regex to try to extract
+        # the "major" and "minor" versions and whether this is the exact tagged
+        # version or whether the tree is between two tagged versions.
+        if [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+            GIT_MAJOR=${BASH_REMATCH[1]}
+            GIT_MINOR=${BASH_REMATCH[2]}
+        fi
+
+        # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+        if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+            echo "Please see more details here: https://semver.org"
+            exit 1
+        fi
+    fi
+
+    GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags)
+}
+
+# borrowed from k8s.io/hack/lib/version.sh and modified
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+version::ldflags() {
+    version::get_version_vars
+
+    local -a ldflags
+    function add_ldflag() {
+        local key=${1}
+        local val=${2}
+        ldflags+=(
+            "-X 'github.com/hivelocity/hivelocity-cloud-controller-manager/hivelocity.${key}=${val}'"
+        )
+    }
+
+    add_ldflag "providerVersion" "${GIT_VERSION}"
+
+    # The -ldflags parameter takes a single string, so join the output.
+    echo "${ldflags[*]-}"
+}
+
+version::ldflags

--- a/hivelocity/cloud.go
+++ b/hivelocity/cloud.go
@@ -36,12 +36,13 @@ type cloud struct {
 const (
 	hivelocityAPIKeyENVVar = "HIVELOCITY_API_KEY" // #nosec G101
 	providerName           = "hivelocity"
-	providerVersion        = "v0.0.1"
 )
 
-var _ cloudprovider.Interface = (*cloud)(nil)
-
-var errEnvVarMissing = fmt.Errorf("environment variable %q is missing or empty", hivelocityAPIKeyENVVar)
+var (
+	providerVersion                          = "dev"
+	_                cloudprovider.Interface = (*cloud)(nil)
+	errEnvVarMissing                         = fmt.Errorf("environment variable %q is missing or empty", hivelocityAPIKeyENVVar)
+)
 
 func init() {
 	cloudprovider.RegisterCloudProvider(providerName, func(config io.Reader) (cloudprovider.Interface, error) {


### PR DESCRIPTION
This commit adds version information.

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What type of PR is this?**
This PR includes versioning information with the executable. 

#### for testing 
Move the following to the init function.
```go
klog.Infof("Hivelocity cloud controller manager %s started\n", providerVersion)
```
`init` function will be the following. 
```go
func init() {
	klog.Infof("Hivelocity cloud controller manager %s started\n", providerVersion)
	cloudprovider.RegisterCloudProvider(providerName, func(config io.Reader) (cloudprovider.Interface, error) {
		return newCloud()
	})
}
```
Since we don't follow semver for this repo, let's create a tag for testing. 
```bash
git tag v0.0.1
```
We will have a tag now, for confirmation we can use `git tag -l` 

Invoke `./hack/version.sh` now. 
```bash
$ ./hack/version.sh
-X 'github.com/hivelocity/hivelocity-cloud-controller-manager/hivelocity.providerVersion=v0.0.1-dirty'
```
The branch is dirty because we've inserted one extra line to the `init` function. 
Pass the above output to `go build` in the following manner. 
```bash
$ go build -ldflags="-X 'github.com/hivelocity/hivelocity-cloud-controller-manager/hivelocity.providerVersion=v0.0.1-dirty'"
```
Invoke the `hivelocity-cloud-controller-manager`binary. 
```bash
$ ./hivelocity-cloud-controller-manager
I1016 12:20:32.018888  774591 cloud.go:48] Hivelocity cloud controller manager v0.0.1-dirty started
--cloud-provider cannot be empty
E1016 12:20:32.021701  774591 run.go:74] "command failed" err="--cloud-provider cannot be empty"
```
Alternatively, we can also use the following. This is something I'm planning to use in `Dockerfile`, `Tiltfile` (if we plan to develop via tilt) and perhaps CI as well. 
```bash
$ go build -ldflags="$(./hack/version.sh)"
```







<!--
Add one of the following kinds:
/kind feature           New functionality.
/kind bug               Fixes a newly discovered bug.
/kind api-change        Adds, removes, or changes an API
/kind cleanup           Adding tests, refactoring, fixing old bugs.
/kind deprecation       Related to a feature/enhancement marked for deprecation.
/kind design            Related to design.
/kind documentation     Adds documentation.
/kind failing-test      CI test case is failing consistently.
/kind flake             CI test case is showing intermittent failures.
/kind other             Related to updating dependencies, minor changes or other.
-->


Fixes #20 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squash commits
- [ ] include documentation
- [ ] add unit tests
